### PR TITLE
#feat: 모바일 환경에서 메인 타이틀 개선

### DIFF
--- a/src/components/atoms/main_title/MobileCircleContainer.tsx
+++ b/src/components/atoms/main_title/MobileCircleContainer.tsx
@@ -1,0 +1,45 @@
+// src/components/MobileCircleContainer.tsx
+import React from "react";
+import Color from "../../ui/Color";
+
+interface MobileCircleContainerProps {
+  color: string;
+  contentColor?: string;
+  size: number;
+  isHovered?: boolean;
+  animate?: boolean;
+  children: React.ReactNode;
+}
+
+const MobileCircleContainer: React.FC<MobileCircleContainerProps> = ({
+  color,
+  contentColor = Color.primary,
+  size,
+  children,
+  isHovered = true,
+  animate = false,
+}) => {
+  return (
+    <div
+      style={{ width: size, height: size, backgroundColor: color }}
+      className="flex justify-center items-center rounded-full"
+    >
+      <div
+        style={{
+          color: contentColor,
+          opacity: isHovered ? 1 : 0,
+          fontSize: "clamp(0rem, calc((100vw - 10.4rem) * 0.086), 4rem)",
+          wordSpacing: "-0.1rem",
+          letterSpacing: "-0.07em",
+        }}
+        className={`flex rounded-full justify-center items-center transition-opacity duration-500 display1ExtraBold ${
+          animate ? (isHovered ? "animate-fadeIn" : "animate-fadeOut") : ""
+        }`}
+      >
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default MobileCircleContainer;

--- a/src/components/atoms/main_title/MobileMenuButton.tsx
+++ b/src/components/atoms/main_title/MobileMenuButton.tsx
@@ -1,0 +1,53 @@
+// src/components/MobileMenuButton.tsx
+import Color from "@/components/ui/Color";
+import React from "react";
+
+interface MobileMenuButtonProps {
+  color?: string; // 예: Color.primary
+  buttonText: string;
+  width: number;
+  height: number;
+  onClick?: React.MouseEventHandler<HTMLButtonElement>;
+  onMouseEnter?: React.MouseEventHandler<HTMLButtonElement>;
+  onMouseLeave?: React.MouseEventHandler<HTMLButtonElement>;
+}
+
+const MobileMenuButton: React.FC<MobileMenuButtonProps> = ({
+  color = Color.primary,
+  buttonText,
+  width,
+  height,
+  onClick,
+  onMouseEnter,
+  onMouseLeave,
+}) => {
+  return (
+    <button
+      style={{
+        width: `${width}px`,
+        height: `${height}px`,
+        borderRadius: `${height}px`,
+        backgroundColor: color,
+      }}
+      onClick={onClick}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      className="flex justify-center items-center cursor-pointer border-none"
+    >
+      <div
+        className="text-white"
+        style={{
+          fontSize: "clamp(0rem, calc((100vw - 10.4rem) * 0.072), 3.6rem)",
+          fontWeight: 700,
+          fontFamily: '"NanumSquareNeoHeavy"',
+          wordSpacing: "-0.1rem",
+          letterSpacing: "-0.07em",
+        }}
+      >
+        {buttonText}
+      </div>
+    </button>
+  );
+};
+
+export default MobileMenuButton;

--- a/src/components/atoms/main_title/MobileRoundedRectangleContainer copy.tsx
+++ b/src/components/atoms/main_title/MobileRoundedRectangleContainer copy.tsx
@@ -1,0 +1,41 @@
+// src/components/MobileRoundedRectangleContainer.tsx
+import React from "react";
+import Color from "../../ui/Color";
+// FontStyle를 Tailwind 커스텀 클래스(`display1ExtraBold`)로 대체한다고 가정합니다.
+
+interface MobileRoundedRectangleContainerProps {
+  color: string;
+  width: number;
+  height: number;
+  text: string;
+}
+
+const MobileRoundedRectangleContainer: React.FC<
+  MobileRoundedRectangleContainerProps
+> = ({ color, width, height, text }) => {
+  return (
+    <div
+      style={{
+        width: `${width}px`,
+        height: `${height}px`,
+        borderRadius: `${height}px`,
+        backgroundColor: color,
+      }}
+      className="flex justify-center items-center"
+    >
+      <div
+        style={{
+          color: Color.primary,
+          fontSize: "clamp(0rem, calc((100vw - 10.4rem) * 0.086), 4.3rem)",
+          wordSpacing: "-0.1rem",
+          letterSpacing: "-0.07em",
+        }}
+        className="display1ExtraBold" // Tailwind 커스텀 폰트 스타일 클래스
+      >
+        {text}
+      </div>
+    </div>
+  );
+};
+
+export default MobileRoundedRectangleContainer;

--- a/src/components/atoms/main_title/MobileRoundedRectangleContainer.tsx
+++ b/src/components/atoms/main_title/MobileRoundedRectangleContainer.tsx
@@ -1,0 +1,41 @@
+// src/components/MobileRoundedRectangleContainer.tsx
+import React from "react";
+import Color from "../../ui/Color";
+// FontStyle를 Tailwind 커스텀 클래스(`display1ExtraBold`)로 대체한다고 가정합니다.
+
+interface MobileRoundedRectangleContainerProps {
+  color: string;
+  width: number;
+  height: number;
+  text: string;
+}
+
+const MobileRoundedRectangleContainer: React.FC<
+  MobileRoundedRectangleContainerProps
+> = ({ color, width, height, text }) => {
+  return (
+    <div
+      style={{
+        width: `${width}px`,
+        height: `${height}px`,
+        borderRadius: `${height}px`,
+        backgroundColor: color,
+      }}
+      className="flex justify-center items-center"
+    >
+      <div
+        style={{
+          color: Color.primary,
+          fontSize: "clamp(0rem, calc((100vw - 10.4rem) * 0.086), 4.3rem)",
+          wordSpacing: "-0.1rem",
+          letterSpacing: "-0.07em",
+        }}
+        className="display1ExtraBold" // Tailwind 커스텀 폰트 스타일 클래스
+      >
+        {text}
+      </div>
+    </div>
+  );
+};
+
+export default MobileRoundedRectangleContainer;

--- a/src/components/molecules/main_title/MobileTopLayerGridItem.tsx
+++ b/src/components/molecules/main_title/MobileTopLayerGridItem.tsx
@@ -1,0 +1,138 @@
+// src/components/MobileTopLayerGridItem.tsx
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import CellType from "../../../enum/CellType"; // js 파일, 값으로 사용
+import Color from "../../ui/Color";
+import CircleContainer from "../../atoms/main_title/CircleContainer";
+import RoundedRectangleContainer from "@/components/atoms/main_title/RoundedRectangleContainer";
+import MenuButton from "../../atoms/main_title/MenuButton";
+import NavigateArrow from "../../../assets/icon/navigate_arrow.svg?react";
+import TopLayerGridItemData from "@/types/TopLayerGridItemData";
+import MobileRoundedRectangleContainer from "@/components/atoms/main_title/MobileRoundedRectangleContainer copy";
+import MobileCircleContainer from "@/components/atoms/main_title/MobileCircleContainer";
+import MobileMenuButton from "@/components/atoms/main_title/MobileMenuButton";
+
+interface MobileTopLayerGridItemProps {
+  data: TopLayerGridItemData;
+  circleSize: number;
+  circleSize2X: number;
+  circleSize3X: number;
+  isHovered: { [key: number]: boolean };
+  handleMouseEnter: (index: number) => void;
+  handleMouseLeave: (index: number) => void;
+  visibleItems: number[];
+}
+
+const MobileTopLayerGridItem: React.FC<MobileTopLayerGridItemProps> = ({
+  data,
+  circleSize,
+  circleSize2X,
+  circleSize3X,
+  isHovered,
+  handleMouseEnter,
+  handleMouseLeave,
+  visibleItems,
+}) => {
+  const navigate = useNavigate();
+
+  // data.delay가 있으면 visibleItems에 포함되어야 보이도록 처리합니다.
+  const isVisible = data.delay ? visibleItems.includes(data.delay) : true;
+
+  // 그리드 배치와 관련된 스타일 (column, row, span, opacity)
+  const gridStyle: React.CSSProperties = {
+    gridColumn: data.position[0],
+    gridRow: data.position[1],
+    gridColumnEnd: `span 1`, // columnSpan이 별도로 전달되지 않았으므로 기본값 1
+    gridRowEnd: `span 1`, // rowSpan 기본값 1
+    opacity: isVisible ? 1 : 0,
+  };
+
+  return (
+    <div
+      style={gridStyle}
+      className="transition-opacity duration-500 ease-in-out"
+    >
+      {data.type === CellType.CIRCLE && (
+        <MobileCircleContainer
+          color={data.color}
+          size={circleSize}
+          children={undefined}
+        />
+      )}
+
+      {data.type === CellType.CIRCLE_WITH_TEXT && (
+        <MobileCircleContainer color={data.color} size={circleSize}>
+          {data.text}
+        </MobileCircleContainer>
+      )}
+
+      {data.type === CellType.CIRCLE_WITH_ICON && (
+        <MobileCircleContainer
+          color={data.color}
+          size={circleSize}
+          isHovered={isHovered[data.index!]}
+          animate={true}
+          contentColor={Color.white}
+        >
+          <NavigateArrow width="30px" height="30px" />
+        </MobileCircleContainer>
+      )}
+
+      {data.type === CellType.HORIZONTAL_RECTANGLE && (
+        <MobileRoundedRectangleContainer
+          color={data.color}
+          height={circleSize}
+          width={circleSize2X}
+          text={data.text ?? ""}
+        />
+      )}
+
+      {data.type === CellType.LONG_HORIZONTAL_RECTANGLE && (
+        <MobileRoundedRectangleContainer
+          color={data.color}
+          height={circleSize}
+          width={circleSize3X}
+          text={data.text as string}
+        />
+      )}
+
+      {data.type === CellType.VERTICAL_RECTANGLE && (
+        <MobileRoundedRectangleContainer
+          color={data.color}
+          height={circleSize2X}
+          width={circleSize}
+          text={""}
+        />
+      )}
+
+      {data.type === CellType.BUTTON && (
+        <MobileMenuButton
+          buttonText={data.buttonText || ""}
+          color={data.color}
+          height={circleSize}
+          width={circleSize2X}
+          onMouseEnter={() => handleMouseEnter(data.index!)}
+          onMouseLeave={() => handleMouseLeave(data.index!)}
+          onClick={() => navigate(data.url || "")}
+        />
+      )}
+
+      {data.type === CellType.TEXT && (
+        <div
+          className="flex text-start"
+          style={{
+            color: Color.primary,
+            fontFamily: "NanumSquareNeoHeavy",
+            fontWeight: 800,
+            lineHeight: 0.92,
+            fontSize: "clamp(0rem, calc((100vw - 60px) * 0.27), 16rem)",
+          }}
+        >
+          HI- ARC
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MobileTopLayerGridItem;

--- a/src/components/organisms/footer/Footer.tsx
+++ b/src/components/organisms/footer/Footer.tsx
@@ -4,7 +4,7 @@ import FooterContactInfo from "@/components/molecules/footer/FooterContactInfo";
 const Footer: React.FC = () => {
   return (
     <div className="flex justify-center items-center w-full bg-[#fffdf0] py-4 pt-15 mt-[40px] mb-[20px]">
-      <div className="w-full max-w-[1000px] px-6 flex flex-col  sm:flex-row justify-between items-center gap-10">
+      <div className="w-full max-w-[1000px] px-6 flex flex-col  sm:flex-row justify-between items-start gap-10">
         {/* 왼쪽: 로고 */}
         <FooterLogo />
         {/* 오른쪽: 연락처 정보 */}

--- a/src/components/organisms/main_title/MainMobileTitle.tsx
+++ b/src/components/organisms/main_title/MainMobileTitle.tsx
@@ -1,0 +1,198 @@
+import React, { useState, useEffect } from "react";
+import BottomLayerGridItem from "../../molecules/main_title/BottomLayerGridItem";
+import TopLayerGridItem from "../../molecules/main_title/TopLayerGridItem";
+import TopLayerGridData from "@/constants/data/main_title/TopLayerGridData";
+import BottomLayerGridData from "@/constants/data/main_title/BottomLayerGridData";
+import MobileTopLayerGridData from "@/constants/data/main_mobile_title/MobileTopLayerGridData";
+import MobileBottomLayerGridData from "@/constants/data/main_mobile_title/MobileBottomLayerGridData";
+import MobileTopLayerGridItem from "@/components/molecules/main_title/MobileTopLayerGridItem";
+
+// ──────────────────────────────────────────────
+// 분리된 컨테이너 컴포넌트들
+// ──────────────────────────────────────────────
+
+interface LayeredContainerProps {
+  width: number;
+  height: number;
+  children: React.ReactNode;
+}
+const LayeredContainer: React.FC<LayeredContainerProps> = ({
+  width,
+  height,
+  children,
+}) => (
+  <div
+    className="relative"
+    style={{ width: `${width}px`, height: `${height}px` }}
+  >
+    {children}
+  </div>
+);
+
+interface GridContainer1Props {
+  size: number;
+  padding: number;
+  children: React.ReactNode;
+}
+const GridContainer1: React.FC<GridContainer1Props> = ({
+  size,
+  padding,
+  children,
+}) => (
+  <div
+    className="grid absolute items-start"
+    style={{
+      gridTemplateColumns: `repeat(5, ${size}px)`,
+      gridTemplateRows: `repeat(9, ${size}px)`,
+      top: `${padding}px`,
+      left: `${padding}px`,
+    }}
+  >
+    {children}
+  </div>
+);
+
+interface GridContainer2Props {
+  cellSize: number;
+  gap: number;
+  children: React.ReactNode;
+}
+const GridContainer2: React.FC<GridContainer2Props> = ({
+  cellSize,
+  gap,
+  children,
+}) => (
+  <div
+    className="grid absolute top-0 left-0 w-full h-full"
+    style={{
+      gridTemplateColumns: `repeat(6, ${cellSize}px)`,
+      gridTemplateRows: `repeat(10, ${cellSize}px)`,
+      gap: `${gap}px`,
+    }}
+  >
+    {children}
+  </div>
+);
+
+// ──────────────────────────────────────────────
+// MainMobileTitle 컴포넌트
+// ──────────────────────────────────────────────
+
+interface MainMobileTitleProps {
+  width?: number | null;
+}
+
+const MainMobileTitle: React.FC<MainMobileTitleProps> = ({ width }) => {
+  // rem 단위를 px로 변환하는 함수
+  const remToPx = (rem: number) => {
+    return (
+      rem * parseFloat(getComputedStyle(document.documentElement).fontSize)
+    );
+  };
+
+  // 동적 너비 계산 함수
+  const getDynamicWidth = () => {
+    const remValue = remToPx(6.0);
+    return Math.min(1000, Math.max(200, window.innerWidth - remValue));
+  };
+
+  // 내부에서 관리하는 동적 너비 상태
+  const [dynamicWidth, setDynamicWidth] = useState<number>(getDynamicWidth());
+
+  useEffect(() => {
+    if (width !== null && width !== undefined) return;
+
+    const handleResize = () => {
+      setDynamicWidth(getDynamicWidth());
+    };
+
+    window.addEventListener("resize", handleResize);
+    handleResize();
+    return () => window.removeEventListener("resize", handleResize);
+  }, [width]);
+
+  // 실제 사용할 너비 결정
+  const finalWidth =
+    width !== null && width !== undefined ? width : dynamicWidth;
+
+  // 비율에 따른 사이즈 계산
+  const itemSize = (128 / 740) * finalWidth;
+  const cornerCurveSize = (78 / 740) * finalWidth;
+  const circleSize = (100 / 740) * finalWidth;
+  const circleSize2X = (228 / 740) * finalWidth;
+  const circleSize3X = (356 / 740) * finalWidth;
+  const paddingSize = (50 / 740) * finalWidth;
+  const gapSize = (28 / 740) * finalWidth;
+  const containerHeight = (1252 / 740) * finalWidth;
+
+  // 상태: visibleItems와 isHovered
+  const [visibleItems, setVisibleItems] = useState<number[]>([]);
+  const [isHovered, setIsHovered] = useState<boolean[]>([
+    false,
+    false,
+    false,
+    false,
+  ]);
+
+  useEffect(() => {
+    // TopLayerGridData에 delay 값이 있는 항목에 대해 visibleItems 상태 업데이트
+    MobileTopLayerGridData.forEach((data) => {
+      if (data.delay) {
+        setTimeout(() => {
+          if (data.delay !== undefined) {
+            setVisibleItems((prev) => [...prev, data.delay!]);
+          }
+        }, data.delay * 200);
+      }
+    });
+  }, []);
+
+  const handleMouseEnter = (index: number) => {
+    setIsHovered((prev) => {
+      const newHovered = [...prev];
+      newHovered[index] = true;
+      return newHovered;
+    });
+  };
+
+  const handleMouseLeave = (index: number) => {
+    setIsHovered((prev) => {
+      const newHovered = [...prev];
+      newHovered[index] = false;
+      return newHovered;
+    });
+  };
+
+  return (
+    <LayeredContainer width={finalWidth} height={containerHeight}>
+      <GridContainer1 padding={paddingSize} size={itemSize}>
+        {MobileBottomLayerGridData.map((data, index) => (
+          <BottomLayerGridItem
+            key={index}
+            data={data}
+            itemSize={itemSize}
+            cornerCurveSize={cornerCurveSize}
+            isHovered={isHovered}
+          />
+        ))}
+      </GridContainer1>
+      <GridContainer2 cellSize={circleSize} gap={gapSize}>
+        {MobileTopLayerGridData.map((data, index) => (
+          <MobileTopLayerGridItem
+            key={index}
+            data={data}
+            circleSize={circleSize}
+            circleSize2X={circleSize2X}
+            circleSize3X={circleSize3X}
+            isHovered={isHovered}
+            handleMouseEnter={handleMouseEnter}
+            handleMouseLeave={handleMouseLeave}
+            visibleItems={visibleItems}
+          />
+        ))}
+      </GridContainer2>
+    </LayeredContainer>
+  );
+};
+
+export default MainMobileTitle;

--- a/src/components/page/HomePage.tsx
+++ b/src/components/page/HomePage.tsx
@@ -1,64 +1,17 @@
-import { useState, useEffect } from "react";
 import Layout from "../templates/PageTemplate";
 import MainTitle from "../organisms/main_title/MainTitle";
-import HiArcGridView from "../organisms/section/SectionGridView";
-import BottomLayerGridData from "@/constants/data/main_title/BottomLayerGridData";
-import TopLayerGridData from "@/constants/data/main_title/TopLayerGridData";
-import IntroduceHiarc from "@/constants/data/introduce_hiarc/IntroduceHiarcBottom";
-import IntroduceHiarcTop from "@/constants/data/introduce_hiarc/IntroduceHiarcTop";
+import MainMobileTitle from "../organisms/main_title/MainMobileTitle";
 
 const HomePage = () => {
-  const [isSmallScreen, setIsSmallScreen] = useState(window.innerWidth < 768);
-  const [text, setText] = useState("");
-  const [isTypingDone, setIsTypingDone] = useState(false);
-
-  // rem 단위를 px로 변환하는 함수
-  const remToPx = (rem: number) => {
-    return (
-      rem * parseFloat(getComputedStyle(document.documentElement).fontSize)
-    );
-  };
-
-  const getMainTitleWidth = () => {
-    const remValue = remToPx(6.0);
-    return Math.min(1000, Math.max(200, window.innerWidth - remValue));
-  };
-
-  const [mainTitleWidth, setMainTitleWidth] = useState(getMainTitleWidth());
-
-  const fullText = "HI-ARC";
-
-  useEffect(() => {
-    const handleResize = () => {
-      setIsSmallScreen(window.innerWidth < 768);
-      setMainTitleWidth(getMainTitleWidth());
-    };
-
-    window.addEventListener("resize", handleResize);
-    handleResize();
-    return () => window.removeEventListener("resize", handleResize);
-  }, []);
-
-  useEffect(() => {
-    if (!isSmallScreen) return;
-
-    let index = 0;
-    const interval = setInterval(() => {
-      if (index < fullText.length) {
-        setText((prev) => prev + fullText[index]);
-        index++;
-      } else {
-        clearInterval(interval);
-        setIsTypingDone(true);
-      }
-    }, 150);
-
-    return () => clearInterval(interval);
-  }, [isSmallScreen]);
-
   return (
     <Layout align="center">
-      <MainTitle />
+      {/* xs 사이즈 이하에서는 모바일 타이틀, xs 이상에서는 일반 타이틀을 보여줍니다. */}
+      <div className="block xs:hidden">
+        <MainMobileTitle />
+      </div>
+      <div className="hidden xs:block">
+        <MainTitle />
+      </div>
     </Layout>
   );
 };

--- a/src/constants/data/main_mobile_title/MobileBottomLayerGridData.ts
+++ b/src/constants/data/main_mobile_title/MobileBottomLayerGridData.ts
@@ -1,0 +1,81 @@
+import Color from "@/components/ui/Color";
+import CellType from "@/enum/CellType";
+import CurvedCornerType from "@/enum/CurevedCornerType";
+import BottomLayerGridItemData from "@/types/BottomLayerGridItemData";
+
+const MobileBottomLayerGridData: BottomLayerGridItemData[] = [
+  {
+    position: [2, 1],
+    type: CellType.CURVE,
+    direction: CurvedCornerType.TOP_RIGHT,
+    backgroundColor: Color.gray,
+  },
+  {
+    position: [5, 1],
+    type: CellType.CURVE,
+    direction: CurvedCornerType.BOTTOM_RIGHT,
+    backgroundColor: Color.orange,
+  },
+  {
+    position: [3, 3],
+    type: CellType.CURVE,
+    direction: CurvedCornerType.BOTTOM_RIGHT,
+    backgroundColor: Color.orange,
+  },
+  {
+    position: [4, 3],
+    type: CellType.CURVE,
+    direction: CurvedCornerType.BOTTOM_RIGHT,
+    backgroundColor: Color.gray,
+  },
+  {
+    position: [5, 3],
+    type: CellType.CURVE,
+    direction: CurvedCornerType.BOTTOM_RIGHT,
+    backgroundColor: Color.gray,
+  },
+  {
+    position: [1, 5],
+    type: CellType.CURVE,
+    direction: CurvedCornerType.BOTTOM_RIGHT,
+    backgroundColor: Color.gray,
+  },
+  {
+    position: [2, 5],
+    type: CellType.CURVE,
+    direction: CurvedCornerType.BOTTOM_RIGHT,
+    backgroundColor: Color.pink,
+  },
+  {
+    position: [2, 5],
+    type: CellType.CURVE,
+    direction: CurvedCornerType.BOTTOM_RIGHT,
+    backgroundColor: Color.pink,
+  },
+  {
+    position: [3, 4],
+    type: CellType.CURVE,
+    direction: CurvedCornerType.BOTTOM_RIGHT,
+    backgroundColor: Color.yellow,
+  },
+  {
+    position: [3, 5],
+    type: CellType.CURVE,
+    direction: CurvedCornerType.BOTTOM_RIGHT,
+    backgroundColor: Color.primary,
+  },
+  {
+    position: [5, 7],
+    type: CellType.CURVE,
+    direction: CurvedCornerType.TOP_RIGHT,
+    backgroundColor: Color.orange,
+  },
+  {
+    position: [5, 9],
+    type: CellType.CURVE,
+    direction: CurvedCornerType.TOP_LEFT,
+    backgroundColor: Color.pink,
+  },
+];
+
+export default MobileBottomLayerGridData;

--- a/src/constants/data/main_mobile_title/MobileTopLayerGridData.ts
+++ b/src/constants/data/main_mobile_title/MobileTopLayerGridData.ts
@@ -1,0 +1,114 @@
+// src/constants/data/main_title/MobileTopLayerGridData.ts
+import Color from "@/components/ui/Color";
+import CellType from "@/enum/CellType";
+import TopLayerGridItemData from "@/types/TopLayerGridItemData";
+
+const MobileTopLayerGridData: TopLayerGridItemData[] = [
+  { position: [1, 1], type: CellType.CIRCLE, color: Color.pink },
+  { position: [2, 1], type: CellType.CIRCLE, color: Color.gray },
+  { position: [3, 1], type: CellType.HORIZONTAL_RECTANGLE, color: Color.gray },
+  { position: [5, 1], type: CellType.CIRCLE, color: Color.orange },
+  { position: [6, 1], type: CellType.CIRCLE, color: Color.orange },
+
+  { position: [1, 2], type: CellType.CIRCLE, color: Color.pink },
+  { position: [2, 2], type: CellType.CIRCLE, color: Color.gray },
+  { position: [3, 2], type: CellType.VERTICAL_RECTANGLE, color: Color.orange },
+  { position: [6, 2], type: CellType.CIRCLE, color: Color.orange },
+
+  { position: [4, 3], type: CellType.CIRCLE, color: Color.gray },
+  { position: [5, 3], type: CellType.CIRCLE, color: Color.gray },
+  { position: [6, 3], type: CellType.CIRCLE, color: Color.primary },
+
+  {
+    position: [1, 4],
+    type: CellType.LONG_HORIZONTAL_RECTANGLE,
+    color: Color.yellow,
+    text: "Solve with",
+  },
+  { position: [4, 4], type: CellType.CIRCLE, color: Color.orange },
+  { position: [5, 4], type: CellType.CIRCLE, color: Color.gray },
+  { position: [6, 4], type: CellType.CIRCLE, color: Color.gray },
+
+  { position: [1, 5], type: CellType.CIRCLE, color: Color.gray },
+  { position: [2, 5], type: CellType.CIRCLE, color: Color.pink },
+  { position: [3, 5], type: CellType.CIRCLE, color: Color.primary },
+  {
+    position: [4, 5],
+    type: CellType.CIRCLE_WITH_TEXT,
+    color: Color.yellow,
+    text: "us",
+  },
+
+  { position: [1, 6], type: CellType.CIRCLE, color: Color.gray },
+  { position: [2, 6], type: CellType.CIRCLE, color: Color.gray },
+  { position: [3, 6], type: CellType.CIRCLE, color: Color.pink },
+  { position: [4, 6], type: CellType.CIRCLE, color: Color.primary },
+  { position: [5, 6], type: CellType.CIRCLE, color: Color.pink },
+  { position: [6, 6], type: CellType.CIRCLE, color: Color.gray },
+
+  { position: [1, 7], type: CellType.CIRCLE, color: Color.gray },
+  { position: [2, 7], type: CellType.CIRCLE, color: Color.gray },
+  { position: [3, 7], type: CellType.CIRCLE, color: Color.gray },
+  { position: [6, 7], type: CellType.CIRCLE, color: Color.orange },
+
+  {
+    position: [1, 8],
+    type: CellType.TEXT,
+    color: Color.primary,
+    text: "HI-ARC",
+  },
+  { position: [4, 8], type: CellType.CIRCLE, color: Color.gray },
+  { position: [5, 8], type: CellType.CIRCLE, color: Color.orange },
+  { position: [6, 8], type: CellType.CIRCLE, color: Color.gray },
+
+  { position: [5, 9], type: CellType.CIRCLE, color: Color.pink },
+  { position: [6, 9], type: CellType.CIRCLE, color: Color.gray },
+
+  { position: [5, 10], type: CellType.CIRCLE, color: Color.gray },
+  { position: [6, 10], type: CellType.CIRCLE, color: Color.pink },
+  // { position: [1, 1], type: CellType.CIRCLE, color: Color.gray, delay: 1 },
+  // { position: [3, 1], type: CellType.CIRCLE, color: Color.gray, delay: 2 },
+  // { position: [5, 6], type: CellType.CIRCLE, color: Color.gray, delay: 3 },
+  // { position: [10, 1], type: CellType.CIRCLE, color: Color.orange, delay: 4 },
+  // { position: [6, 1], type: CellType.CIRCLE, color: Color.gray, delay: 5 },
+  // { position: [10, 6], type: CellType.CIRCLE, color: Color.gray, delay: 6 },
+  // { position: [1, 3], type: CellType.CIRCLE, color: Color.gray, delay: 7 },
+  // { position: [9, 6], type: CellType.CIRCLE, color: Color.pink, delay: 8 },
+  // { position: [5, 1], type: CellType.CIRCLE, color: Color.pink, delay: 9 },
+  // { position: [1, 4], type: CellType.TEXT, color: Color.primary, delay: 10 },
+
+  {
+    position: [4, 7],
+    type: CellType.BUTTON,
+    color: Color.primary,
+    buttonText: "학회 소개",
+    index: 0,
+    url: "introduce_hiarc",
+  },
+  {
+    position: [4, 2],
+    type: CellType.BUTTON,
+    color: Color.primary,
+    buttonText: "스터디",
+    index: 1,
+    url: "study",
+  },
+  {
+    position: [1, 3],
+    type: CellType.BUTTON,
+    color: Color.primary,
+    buttonText: "학회 활동",
+    index: 2,
+    url: "activity",
+  },
+  {
+    position: [5, 5],
+    type: CellType.BUTTON,
+    color: Color.primary,
+    buttonText: "수상 경력",
+    index: 3,
+    url: "award",
+  },
+];
+
+export default MobileTopLayerGridData;


### PR DESCRIPTION
- xs 이하 화면에서는 MainMobileTitle 표시, xs 이상에서는 MainTitle 표시
- 기존 반응형 처리 로직을 제거하고 Tailwind 클래스로 처리

#fix: 푸터 레이아웃 정렬 수정
- 푸터 내부 요소 정렬을 items-center에서 items-start로 변경
- 작은 화면에서 요소 간 배치가 더 자연스럽게 표시되도록 조정

#refactor: 불필요한 상태 및 효과 제거
- useState와 useEffect로 처리하던 반응형 로직을 Tailwind 클래스로 대체
- remToPx 변환 로직 및 윈도우 리사이징 이벤트 리스너 제거
- 불필요한 타이핑 애니메이션 로직 삭제