### PR TITLE
#refactor: StudyPage 데이터 구조 개선

### DIFF
--- a/src/components/page/StudyPage.tsx
+++ b/src/components/page/StudyPage.tsx
@@ -12,9 +12,11 @@ import BasicStudy2025HeaderTopData from "@/constants/data/study/study_2025_grid_
 import ElementaryStudy2025HeaderTopData from "@/constants/data/study/study_2025_grid_data/mobile/ElementaryStudy2025HeaderTopData";
 import AnimatedContainer from "../atoms/common/AnimatedContainer";
 import BasicStudy2024HeaderTopData from "@/constants/data/study/study_2024_grid_data/mobile/BasicStudy2024HeaderTopData";
-import PsManualTopData from "@/constants/data/study/PsManualTopData";
+import PsManualTopData from "@/constants/data/study/study_2024_grid_data/mobile/PsManualTopData";
 import ElementaryStudy2024HeaderTopData from "@/constants/data/study/study_2024_grid_data/mobile/ElementaryStudy2024HeaderTopData";
 import InterMediateStudy2025HeaderData from "@/constants/data/study/study_2025_grid_data/mobile/IntermediateStudy2025HeaderTopData";
+import Study2025HeaderTopData2 from "@/constants/data/study/study_2025_grid_data/Study2025HeaderTopData2";
+import Study2024HeaderTopData2 from "@/constants/data/study/study_2024_grid_data/Study2024HeaderTopData2";
 
 const StudyPlanWrapper = styled.div`
   display: flex;
@@ -112,7 +114,7 @@ const StudyPage: React.FC = () => {
             rowCount={1}
             colCount={12}
             bottomLayerGridData={[]}
-            topLayerGridData={InterMediateStudy2025HeaderData}
+            topLayerGridData={Study2025HeaderTopData2}
           />
         </AnimatedContainer>
       </DesktopOnly>
@@ -176,7 +178,7 @@ const StudyPage: React.FC = () => {
             rowCount={1}
             colCount={12}
             bottomLayerGridData={[]}
-            topLayerGridData={PsManualTopData}
+            topLayerGridData={Study2024HeaderTopData2}
           />
         </DesktopOnly>
       </AnimatedContainer>

--- a/src/constants/data/study/study_2024_grid_data/Study2024HeaderTopData2.ts
+++ b/src/constants/data/study/study_2024_grid_data/Study2024HeaderTopData2.ts
@@ -1,0 +1,15 @@
+import Color from "@/components/ui/Color";
+import CellType from "@/enum/CellType";
+import TopLayerGridItemData from "@/types/TopLayerGridItemData";
+
+const Study2024HeaderTopData2: TopLayerGridItemData[] = [
+  {
+    position: [1, 1],
+    type: CellType.BORDERED_LONG_HORIZONTAL_RECTANGLE,
+    backgroundColor: Color.transparent,
+    contentColor: Color.orange,
+    text: "PS 사용설명서",
+  },
+];
+
+export default Study2024HeaderTopData2;

--- a/src/constants/data/study/study_2024_grid_data/mobile/ElementaryStudy2024HeaderTopData.ts
+++ b/src/constants/data/study/study_2024_grid_data/mobile/ElementaryStudy2024HeaderTopData.ts
@@ -25,7 +25,6 @@ const ElementaryStudy2024HeaderTopData: TopLayerGridItemData[] = [
     contentColor: Color.orange,
     text: "초급 스터디",
   },
-
   {
     position: [8, 1],
     type: CellType.ICON,

--- a/src/constants/data/study/study_2024_grid_data/mobile/PsManualTopData.ts
+++ b/src/constants/data/study/study_2024_grid_data/mobile/PsManualTopData.ts
@@ -5,6 +5,20 @@ import TopLayerGridItemData from "@/types/TopLayerGridItemData";
 const PsManualTopData: TopLayerGridItemData[] = [
   {
     position: [1, 1],
+    type: CellType.HORIZONTAL_RECTANGLE,
+    backgroundColor: Color.orange,
+    contentColor: Color.white,
+    text: "2024",
+  },
+  {
+    position: [3, 1],
+    type: CellType.HORIZONTAL_RECTANGLE,
+    backgroundColor: Color.orange,
+    contentColor: Color.white,
+    text: "2학기",
+  },
+  {
+    position: [5, 1],
     type: CellType.BORDERED_LONG_HORIZONTAL_RECTANGLE,
     backgroundColor: Color.transparent,
     contentColor: Color.orange,

--- a/src/constants/data/study/study_2025_grid_data/Study2025HeaderTopData2.ts
+++ b/src/constants/data/study/study_2025_grid_data/Study2025HeaderTopData2.ts
@@ -1,0 +1,15 @@
+import Color from "@/components/ui/Color";
+import CellType from "@/enum/CellType";
+import TopLayerGridItemData from "@/types/TopLayerGridItemData";
+
+const Study2025HeaderTopData2: TopLayerGridItemData[] = [
+  {
+    position: [1, 1],
+    type: CellType.BORDERED_LONG_HORIZONTAL_RECTANGLE,
+    backgroundColor: Color.transparent,
+    contentColor: Color.orange,
+    text: "중급 스터디",
+  },
+];
+
+export default Study2025HeaderTopData2;

--- a/src/constants/data/study/study_2025_grid_data/mobile/IntermediateStudy2025HeaderTopData.ts
+++ b/src/constants/data/study/study_2025_grid_data/mobile/IntermediateStudy2025HeaderTopData.ts
@@ -5,6 +5,20 @@ import TopLayerGridItemData from "@/types/TopLayerGridItemData";
 const InterMediateStudy2025HeaderData: TopLayerGridItemData[] = [
   {
     position: [1, 1],
+    type: CellType.HORIZONTAL_RECTANGLE,
+    backgroundColor: Color.orange,
+    contentColor: Color.white,
+    text: "2025",
+  },
+  {
+    position: [3, 1],
+    type: CellType.HORIZONTAL_RECTANGLE,
+    backgroundColor: Color.orange,
+    contentColor: Color.white,
+    text: "1학기",
+  },
+  {
+    position: [5, 1],
     type: CellType.BORDERED_LONG_HORIZONTAL_RECTANGLE,
     backgroundColor: Color.transparent,
     contentColor: Color.orange,


### PR DESCRIPTION
- Study2025HeaderTopData2, Study2024HeaderTopData2로 데이터 파일 변경
- PsManualTopData를 study_2024_grid_data 디렉토리로 이동 및 기존 경로 제거

#fix: IntermediateStudy2025HeaderTopData 수정
- 2025년도 및 학기 정보를 추가하여 더 직관적으로 표시

#style: 불필요한 공백 제거
- ElementaryStudy2024HeaderTopData에서 불필요한 개행 제거